### PR TITLE
Adds :crypto as a dependency in extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,9 @@ defmodule UUID.Mixfile do
 
   # Application configuration.
   def application do
-    []
+    [
+      extra_applications: [:crypto]
+    ]
   end
 
   # List of dependencies.


### PR DESCRIPTION
This is in order to stop Elixir 1.11 warning about undeclared dependencies.